### PR TITLE
Use lldb shell script when running on MacOSX

### DIFF
--- a/core/unix/src/TUnixSignalManager.cxx
+++ b/core/unix/src/TUnixSignalManager.cxx
@@ -307,9 +307,7 @@ void TUnixSignalManager::Init()
    }
 #endif
 
-#ifdef R__LINUX
    StackTraceHelperInit();
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -530,11 +528,7 @@ void TUnixSignalManager::DispatchSignals(ESignals sig)
 
    if ((sig == kSigIllegalInstruction) || (sig == kSigSegmentationViolation) || (sig == kSigBus) || (sig == kSigFloatingException))
    {
-#if defined(R__LINUX)
       StackTraceTriggerThread();
-#elif defined(R__MACOSX)
-      StackTrace();
-#endif
       signal(sig, SIG_DFL);
       raise(sig);
       if (gApplication)

--- a/core/unix/src/TUnixSignalManager.cxx
+++ b/core/unix/src/TUnixSignalManager.cxx
@@ -296,12 +296,20 @@ void TUnixSignalManager::Init()
    }
 
 #ifdef ROOTETCDIR
+#if defined(R__MACOSX)
+   if(snprintf(gStackTraceHelper.fPidString, kStringLength-1, "%s/lldb-backtrace.sh", ROOTETCDIR) >= kStringLength) {
+#else
    if(snprintf(gStackTraceHelper.fPidString, kStringLength-1, "%s/gdb-backtrace.sh", ROOTETCDIR) >= kStringLength) {
+#endif
       SignalSafeErrWrite("Unable to pre-allocate executable information");
       return;
    }
 #else
+#if defined(R__MACOSX)
+   if(snprintf(gStackTraceHelper.fPidString, kStringLength-1, "%s/etc/lldb-backtrace.sh", gSystem->Getenv("ROOTSYS")) >= kStringLength) {
+#else
    if(snprintf(gStackTraceHelper.fPidString, kStringLength-1, "%s/etc/gdb-backtrace.sh", gSystem->Getenv("ROOTSYS")) >= kStringLength) {
+#endif
       SignalSafeErrWrite("Unable to pre-allocate executable information");
       return;
    }

--- a/core/unix/src/TUnixSignalManager.cxx
+++ b/core/unix/src/TUnixSignalManager.cxx
@@ -97,6 +97,17 @@
 
 class TFdSet;
 
+static const int kStringLength = 255;
+
+struct StackTraceHelper_t {
+   char  fShellExec[kStringLength];
+   char  fPidString[kStringLength];
+   char  fPidNum[kStringLength];
+   int   fParentToChild[2];
+   int   fChildToParent[2];
+   std::unique_ptr<std::thread> fHelperThread;
+};
+
 #if defined(HAVE_DLADDR) && !defined(R__MACOSX)
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -222,23 +233,7 @@ static int SignalSafeErrWrite(const char *text) {
 
 //---- helper -----------------------------------------------------------------
 
-static const int kStringLength = 255;
-
-static struct StackTraceHelper_t {
-   char  fShellExec[kStringLength];
-   char  fPidString[kStringLength];
-   char  fPidNum[kStringLength];
-   int   fParentToChild[2];
-   int   fChildToParent[2];
-   std::unique_ptr<std::thread> fHelperThread;
-} gStackTraceHelper = {       // the order of the signals should be identical
-   { },
-   { },
-   { },
-   {-1,-1},
-   {-1,-1},
-   nullptr
-};
+static StackTraceHelper_t gStackTraceHelper;
 
 static char * const kStackArgv[] = {gStackTraceHelper.fShellExec, gStackTraceHelper.fPidString, gStackTraceHelper.fPidNum, nullptr};
 
@@ -277,6 +272,7 @@ void TUnixSignalManager::Init()
    gStackTraceHelper.fParentToChild[1] = -1;
    gStackTraceHelper.fChildToParent[0] = -1;
    gStackTraceHelper.fChildToParent[1] = -1;
+   gStackTraceHelper.fHelperThread = nullptr;
 
    //--- install default handlers
    UnixSignal(kSigChild,                 SigHandler);

--- a/core/unix/src/TUnixSignalManager.cxx
+++ b/core/unix/src/TUnixSignalManager.cxx
@@ -307,7 +307,9 @@ void TUnixSignalManager::Init()
    }
 #endif
 
+#ifdef R__LINUX
    StackTraceHelperInit();
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -528,7 +530,11 @@ void TUnixSignalManager::DispatchSignals(ESignals sig)
 
    if ((sig == kSigIllegalInstruction) || (sig == kSigSegmentationViolation) || (sig == kSigBus) || (sig == kSigFloatingException))
    {
+#if defined(R__LINUX)
       StackTraceTriggerThread();
+#elif defined(R__MACOSX)
+      StackTrace();
+#endif
       signal(sig, SIG_DFL);
       raise(sig);
       if (gApplication)

--- a/core/unix/src/TUnixSignalManager.cxx
+++ b/core/unix/src/TUnixSignalManager.cxx
@@ -272,6 +272,12 @@ void TUnixSignalManager::Init()
 
    fSignals    = new TFdSet;
 
+   //--- initialize pipe-related data structer here, macosx does not recognize their values if they were inialized after UnixSignal functions
+   gStackTraceHelper.fParentToChild[0] = -1;
+   gStackTraceHelper.fParentToChild[1] = -1;
+   gStackTraceHelper.fChildToParent[0] = -1;
+   gStackTraceHelper.fChildToParent[1] = -1;
+
    //--- install default handlers
    UnixSignal(kSigChild,                 SigHandler);
    UnixSignal(kSigBus,                   SigHandler);
@@ -300,11 +306,6 @@ void TUnixSignalManager::Init()
       return;
    }
 #endif
-
-   gStackTraceHelper.fParentToChild[0] = -1;
-   gStackTraceHelper.fParentToChild[1] = -1;
-   gStackTraceHelper.fChildToParent[0] = -1;
-   gStackTraceHelper.fChildToParent[1] = -1;
 
    StackTraceHelperInit();
 }

--- a/etc/lldb-backtrace.sh
+++ b/etc/lldb-backtrace.sh
@@ -14,7 +14,7 @@ if [ `uname -s` != "Darwin" ]; then
 else
 
    if test $# -lt 1; then
-      echo "Usage: ${tempname} <process-id> [gdb-mess-file]" 1>&2
+      echo "Usage: ${tempname} <process-id>" 1>&2
       exit 1
    fi
 
@@ -24,7 +24,7 @@ else
       exit 1
    fi
 
-   backtrace="thread apply all bt"
+   backtrace="thread backtrace all"
 
    echo $backtrace > $TMPFILE
 

--- a/etc/lldb-backtrace.sh
+++ b/etc/lldb-backtrace.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# This script is used by TUnixSystem::StackTrace() on MacOS X if lldb is supported.
+
+tempname=`basename $0 .sh`
+
+OUTFILE=/dev/stdout
+
+if [ `uname -s` != "Darwin" ]; then
+
+   echo "lldb stacktrace is only supported on MacOSX."
+   exit 1
+
+else
+
+   if test $# -lt 1; then
+      echo "Usage: ${tempname} <process-id> [gdb-mess-file]" 1>&2
+      exit 1
+   fi
+
+   TMPFILE=`mktemp -q /tmp/${tempname}.XXXXXX`
+   if test $? -ne 0; then
+      echo "${tempname}: can't create temp file, exiting..." 1>&2
+      exit 1
+   fi
+
+   backtrace="thread apply all bt"
+
+   echo $backtrace > $TMPFILE
+
+   LLDB=${LLDB:-lldb}
+
+   # Run LLDB, strip out unwanted noise.
+   $LLDB -b -x -s $TMPFILE -p $1 2>&1  < /dev/null |
+   sed -n \
+    -e '/[Tt]hread #[0-9]/p' \
+    -e '/[Ff]rame #[0-9]/p' > $OUTFILE
+
+   rm -f $TMPFILE
+
+fi


### PR DESCRIPTION
Hi Philippe,

I talked to Brian and we think we'd better to keep macosx single thread and keep it still calling macosx_backtrace() function to print out stack frames. I am waiting for Axel to finish macosx_backtrace().

Zhe