### PR TITLE
Resolves a crash when decompressing BLAST

### DIFF
--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -379,6 +379,7 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
       return;
    } else if (is_valid_header_blast(src)) {
       R__unzipBLAST(srcsize, src, tgtsize, tgt, irep);
+      return;
    }
 
    /* Old zlib format */


### PR DESCRIPTION
Adding a "return;" to make the code flow similar to other decompressors resolves a number of errors like the following during decompression:
```
R__unzip: error during decompression
```
As far as I can tell, the BLAST compression and decompression are both working as intended after this fix!