### PR TITLE
Initial implementation of using Accelogic compression (RLE-Huffman) on integer types

### DIFF
--- a/core/accelogic/src/ZipAccelogic.cxx
+++ b/core/accelogic/src/ZipAccelogic.cxx
@@ -31,14 +31,47 @@ void R__zipBLAST(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, 
 
    size_t out_size;
 
-   if (cxlevel <= 71 && (*srcsize % 4 == 0)) {
-      size_t float_size = *srcsize / 4;
+   if (cxlevel <= 71 && (*srcsize % sizeof(float) == 0)) {
+      size_t float_size = *srcsize / sizeof(float);
       // Use "absSense".  We shift the request config from [1,71] to [-60, 10]
       auto absSensLevel = cxlevel - 61;
       // Note: We need to check the source really start of a float boundary.
       // Note: We need to upgrade blast to avoid the memcpy (which is IN ADDITION to an internal copy already!!!)
       char *staging = nullptr;
       out_size = blast1_compress<true>(absSensLevel, (float*)src, float_size, staging);
+      if ( (out_size + kHeaderSize) > (size_t)*tgtsize ) {
+         delete [] staging;
+         return;
+      }
+      memcpy(tgt + kHeaderSize, staging, out_size);
+      delete [] staging;
+      *irep = out_size + kHeaderSize;
+   } else if (cxlevel <= 79) {
+      // Use "RLE.  cx level determines data type
+      // Note: We need to check the source really start of a boundary.
+      // Note: We need to upgrade blast to avoid the memcpy (which is IN ADDITION to an internal copy already!!!)
+      char *staging = nullptr;
+      // out_size = blast2_compress<T,true>((T*)src, *srcsize, staging);
+      if (cxlevel == 72) {
+         out_size = blast2_compress<char,true>(src, *srcsize, staging);
+      } else if (cxlevel == 73 && (*srcsize % sizeof(short) == 0)) {
+         out_size = blast2_compress<short,true>((short*)src, *srcsize, staging);
+      } else if (cxlevel == 74 && (*srcsize % sizeof(int) == 0)) {
+         out_size = blast2_compress<int,true>((int*)src, *srcsize, staging);
+      } else if (cxlevel == 75 && (*srcsize % sizeof(long long) == 0)) {
+         out_size = blast2_compress<long long,true>((long long*)src, *srcsize, staging);
+      } else if (cxlevel == 76) {
+         out_size = blast2_compress<unsigned char,true>((unsigned char*) src, *srcsize, staging);
+      } else if (cxlevel == 77 && (*srcsize % sizeof(unsigned short) == 0)) {
+         out_size = blast2_compress<unsigned short,true>((unsigned short*)src, *srcsize, staging);
+      } else if (cxlevel == 78 && (*srcsize % sizeof(unsigned int) == 0)) {
+         out_size = blast2_compress<unsigned int,true>((unsigned int*)src, *srcsize, staging);
+      } else if (cxlevel == 79 && (*srcsize % sizeof(unsigned long long) == 0)) {
+         out_size = blast2_compress<unsigned long long,true>((unsigned long long*)src, *srcsize, staging);
+      } else {
+         // not proper length
+         return;
+      }
       if ( (out_size + kHeaderSize) > (size_t)*tgtsize ) {
          delete [] staging;
          return;
@@ -74,13 +107,15 @@ void R__unzipBLAST(int *srcsize, unsigned char *src, int *tgtsize, unsigned char
 
    auto cxlevel = src[2];
 
+   size_t out_size;
+
    if (cxlevel <= 71) {
       // Use "absSense".  We shift the request config from [1,71] to [-60, 10]
       auto absSensLevel = cxlevel - 61;
       // Note: We need to check the destination really start of a float boundary.
       float *staging = nullptr;
       size_t float_size = blast1_decompress<true>(absSensLevel, (char*)(&src[kHeaderSize]), *srcsize, staging);
-      size_t out_size = float_size * 4;
+      out_size = float_size * sizeof(float);
       // Note: We need to upgrade blast to avoid the memcpy
       if ( out_size > (size_t)*tgtsize ) {
          delete [] staging;
@@ -89,7 +124,29 @@ void R__unzipBLAST(int *srcsize, unsigned char *src, int *tgtsize, unsigned char
       memcpy(tgt, staging, out_size);
       delete [] staging;
       *irep = out_size;
-
+   } else if (cxlevel <= 79) {
+      // Use "RLE.  cx level determines data type
+      // Note: We need to check the destination really start of a short boundary.
+      char *staging = nullptr;
+      char*& stagingPtr = staging;
+      switch (cxlevel) {
+         case (79) : out_size = blast2_decompress<unsigned long long,true>((char*)(&src[kHeaderSize]), *srcsize, (unsigned long long*&) stagingPtr); break;
+         case (78) : out_size = blast2_decompress<unsigned int,true>((char*)(&src[kHeaderSize]), *srcsize, (unsigned int*&) stagingPtr); break;
+         case (77) : out_size = blast2_decompress<unsigned short,true>((char*)(&src[kHeaderSize]), *srcsize, (unsigned short*&) stagingPtr); break;
+         case (76) : out_size = blast2_decompress<unsigned char,true>((char*)(&src[kHeaderSize]), *srcsize, (unsigned char*&) stagingPtr);
+         case (75) : out_size = blast2_decompress<long long,true>((char*)(&src[kHeaderSize]), *srcsize, (long long*&) stagingPtr); break;
+         case (74) : out_size = blast2_decompress<int,true>((char*)(&src[kHeaderSize]), *srcsize, (int*&) stagingPtr); break;
+         case (73) : out_size = blast2_decompress<short,true>((char*)(&src[kHeaderSize]), *srcsize, (short*&) stagingPtr); break;
+         default   : out_size = blast2_decompress<char,true>((char*)(&src[kHeaderSize]), *srcsize, staging);
+      }
+      // Note: We need to upgrade blast to avoid the memcpy
+      if ( out_size > (size_t)*tgtsize ) {
+         delete [] staging;
+         return;
+      }
+      memcpy(tgt, staging, out_size);
+      delete [] staging;
+      *irep = out_size;
    } else {
       // Need to handle the other engine
       return;


### PR DESCRIPTION
- (un)zip functions aren't templated in this file, and it isn't obvious to me that there's a way to determine the data type inside the buffer from within this code. If so, that would be better. For now, I use cxlevel of 72-79 to identify the data type (char, short, int, long long, and then repeat the same but unsigned for 76-79).
- Internet searches have not led me to a clear answer on whether "delete [] staging" needs "staging" to be the proper data type pointer (e.g. char* vs. short* vs. int*). I didn't notice any difference between casting and not casting the pointer type when en/decoding unsigned shorts, but there were other issues with unsigned shorts (those issues were consistent regardless of the cast in this spot).