### PR TITLE
PrecisionCascade connections to compression functions

### DIFF
--- a/core/accelogic/inc/ZipAccelogic.h
+++ b/core/accelogic/inc/ZipAccelogic.h
@@ -14,9 +14,9 @@
 
 #include "EDataType.h"
 
-void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int **tgtsizes, char **tgts, int tgt_number, int *irep, EDataType datatype = EDataType::kNoType_t);
+void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, EDataType datatype = EDataType::kNoType_t);
 
-void R__unzipBLAST(int **srcsizes, unsigned char **srcs, int *tgtsize, unsigned char *tgt, int src_number, int *irep);
+void R__unzipBLAST(int *srcsize, unsigned char **srcs, int *tgtsize, unsigned char *tgt, int src_number, int *irep);
 
 // The below two interfaces are to maintain backward compatibility until RZip.cxx is updated to use the above two interfaces
 

--- a/core/zip/inc/RZip.h
+++ b/core/zip/inc/RZip.h
@@ -25,7 +25,7 @@ extern "C" unsigned long R__memcompress(char *tgt, unsigned long tgtsize, char *
 extern "C" void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
                                         EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
 
-extern "C" void R__zipPrecisionCascade(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
+extern "C" void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
                                         EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
 
 /**

--- a/core/zip/inc/RZip.h
+++ b/core/zip/inc/RZip.h
@@ -26,7 +26,7 @@ extern "C" void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, in
                                         EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
 
 extern "C" void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
-                                        EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
+                                       EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
 
 /**
  * This is a historical definition, prior to ROOT supporting multiple algorithms in a single file.  Use

--- a/core/zip/inc/RZip.h
+++ b/core/zip/inc/RZip.h
@@ -25,6 +25,9 @@ extern "C" unsigned long R__memcompress(char *tgt, unsigned long tgtsize, char *
 extern "C" void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
                                         EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
 
+extern "C" void R__zipPrecisionCascade(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues,
+                                        EDataType datatype = EDataType::kNoType_t, int configsize = 0, char *configarray = nullptr);
+
 /**
  * This is a historical definition, prior to ROOT supporting multiple algorithms in a single file.  Use
  * R__zipMultipleAlgorithm instead.
@@ -32,6 +35,8 @@ extern "C" void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, in
 extern "C" void R__zip(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep);
 
 extern "C" void R__unzip(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep, int configsize = 0, char *configarray = nullptr);
+
+extern "C" void R__unzipPrecisionCascade(int *srcsize, unsigned char **srcs, int *tgtsize, unsigned char *tgt, int src_number, int *irep, int configsize = 0, char *configarray = nullptr);
 
 extern "C" int R__unzip_header(int *srcsize, unsigned char *src, int *tgtsize);
 

--- a/core/zip/src/Compression.cxx
+++ b/core/zip/src/Compression.cxx
@@ -11,6 +11,7 @@
 
 #include "Compression.h"
 #include <stdexcept>
+#include <string>
 #include "PrecisionCascadeConfigArrayContent.h"
 
 namespace ROOT {

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -131,7 +131,7 @@ void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, 
       return;
    }
 
-   auto content = reinterpret_cast<PrecisionCascadeConfigArrayContent*>(fConfigArray);
+   auto content = reinterpret_cast<ROOT::Internal::PrecisionCascadeConfigArrayContent*>(configarray);
    (void) configsize;
    assert(content && (content->SizeOf() == configsize));
    Int_t *cxlevels = content->GetLevels();  // This an array of size `content->fLen`

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -14,6 +14,7 @@
 #include "ZipLZ4.h"
 #include "ZipZSTD.h"
 #include "ZipAccelogic.h"
+#include "PrecisionCascadeConfigArrayContent.h"
 
 #include "zlib.h"
 
@@ -129,6 +130,10 @@ void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, 
       memset(irep,0,tgt_number*sizeof(int));
       return;
    }
+
+   auto content = reinterpret_cast<PrecisionCascadeConfigArrayContent*>(fConfigArray);
+   assert(content->SizeOf() == configsize);
+   Int_t *cxlevels = content->GetLevels();  // This an array of size `content->fLen`
 
    for (int tgt_idx=0; tgt_idx<tgt_number; tgt_idx++) {
       // can only be 0 for the last of multiple (not just one) targets

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -132,7 +132,7 @@ void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, 
    }
 
    auto content = reinterpret_cast<PrecisionCascadeConfigArrayContent*>(fConfigArray);
-   assert(content->SizeOf() == configsize);
+   assert(content && (content->SizeOf() == configsize));
    Int_t *cxlevels = content->GetLevels();  // This an array of size `content->fLen`
 
    for (int tgt_idx=0; tgt_idx<tgt_number; tgt_idx++) {

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -120,9 +120,9 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   }
 }
 
-void R__zipPrecisionCascade(int* cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm,
+void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm,
                              EDataType datatype /* = kNoType_t */,
-                             int /* configsize = 0 */, char * /* configarray = nullptr */)
+                             int configsize /* = 0 */, char * configarray /* = nullptr */)
 {
 
    if (*srcsize < 1 + HDRSIZE_BLAST + 1) {

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -132,6 +132,7 @@ void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, 
    }
 
    auto content = reinterpret_cast<PrecisionCascadeConfigArrayContent*>(fConfigArray);
+   (void) configsize;
    assert(content && (content->SizeOf() == configsize));
    Int_t *cxlevels = content->GetLevels();  // This an array of size `content->fLen`
 

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1288,12 +1288,11 @@ Int_t TBasket::WriteBuffer()
       char *configArray = fBranch->GetConfigArray();
 
       std::vector<char*> precisionCascades;
-      std::vector<Int_t> nouts, bufmaxs, cxlevels;
+      std::vector<Int_t> nouts, bufmaxs;
       auto doPrecisionCascades = (fBranch->GetPrecisionCascades() && !fBranch->GetPrecisionCascades()->empty());
       if (doPrecisionCascades)
       {
          precisionCascades.push_back(bufcur);
-         cxlevels.push_back(cxlevel); 
          auto tree = fBranch->GetTree();
          auto basketnumber = fBranch->GetWriteBasket();
          for(auto brpc : *fBranch->GetPrecisionCascades()) {
@@ -1302,7 +1301,6 @@ Int_t TBasket::WriteBuffer()
             R__SizeBuffer(*cascade_buffer, buflen);
             cascade_buffer->SetWriteMode();
             precisionCascades.push_back( cascade_buffer->Buffer() + cascade_basket->GetKeylen() );
-            cxlevels.push_back(cxlevel); // WRONG! From where do we get the cxlevels of the precision cascade?
             nouts.assign(precisionCascades.size(),0);
          }
       }
@@ -1325,7 +1323,7 @@ Int_t TBasket::WriteBuffer()
          // (see fCompressedBufferRef in constructor).
          if (doPrecisionCascades) {
             bufmaxs.assign(precisionCascades.size(),bufmax);  // assuming bufmax is the same for each of the precisionCascade buffers
-            R__zipPrecisionCascade(cxlevels.data(), &bufmax, objbuf, bufmaxs.data(), precisionCascades.data(), precisionCascades.size(), nouts.data(), cxAlgorithm, datatype, configArraySize, configArray);
+            R__zipPrecisionCascade(&bufmax, objbuf, bufmaxs.data(), precisionCascades.data(), precisionCascades.size(), nouts.data(), cxAlgorithm, datatype, configArraySize, configArray);
             nout = nouts[0];
          } else {
             R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm, datatype, configArraySize, configArray);

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1293,7 +1293,6 @@ Int_t TBasket::WriteBuffer()
       if (doPrecisionCascades)
       {
          precisionCascades.push_back(bufcur);
-         cxlevels.push_back(cxlevel); 
          auto tree = fBranch->GetTree();
          auto basketnumber = fBranch->GetWriteBasket();
          for(auto brpc : *fBranch->GetPrecisionCascades()) {

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1293,6 +1293,7 @@ Int_t TBasket::WriteBuffer()
       if (doPrecisionCascades)
       {
          precisionCascades.push_back(bufcur);
+         cxlevels.push_back(cxlevel); 
          auto tree = fBranch->GetTree();
          auto basketnumber = fBranch->GetWriteBasket();
          for(auto brpc : *fBranch->GetPrecisionCascades()) {
@@ -1304,8 +1305,6 @@ Int_t TBasket::WriteBuffer()
             nouts.assign(precisionCascades.size(),0);
          }
       }
-
-
 
       for (Int_t i = 0; i < nbuffers; ++i) {
          if (i == nbuffers - 1) bufmax = fObjlen - nzip;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -636,7 +636,6 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file, Int_t bas
          }
          nins.assign(precisionCascades.size(),0);
       }
-      auto doPrecisionCascades = (!precisionCascades.empty()); // decide before inserting primary buffer pointer at beginning
 
       // Optional monitor for zip time profiling.
       Double_t start = 0;
@@ -646,10 +645,6 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file, Int_t bas
 
       Int_t configArraySize = fBranch->GetConfigArraySize();
       char *configArray = fBranch->GetConfigArray();
-      if (doPrecisionCascades) {
-         precisionCascades.insert(precisionCascades.begin(),rawCompressedObjectBuffer);
-         nins.assign(precisionCascades.size(),0);
-      }
 
       // Unzip all the compressed objects in the compressed object buffer.
       while (1) {
@@ -1306,14 +1301,9 @@ Int_t TBasket::WriteBuffer()
             R__SizeBuffer(*cascade_buffer, buflen);
             cascade_buffer->SetWriteMode();
             precisionCascades.push_back( cascade_buffer->Buffer() + cascade_basket->GetKeylen() );
+            cxlevels.push_back(cxlevel); // WRONG! From where do we get the cxlevels of the precision cascade?
             nouts.assign(precisionCascades.size(),0);
          }
-      }
-      auto doPrecisionCascades = (!precisionCascades.empty()); // decide before inserting primary buffer pointer at beginning
-      if (doPrecisionCascades) {
-         precisionCascades.insert(precisionCascades.begin(),bufcur);
-         cxlevels.insert(cxlevels.begin(),cxlevel);
-         nouts.assign(precisionCascades.size(),0);
       }
 
 

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -636,6 +636,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file, Int_t bas
          }
          nins.assign(precisionCascades.size(),0);
       }
+      auto doPrecisionCascades = (!precisionCascades.empty()); // decide before inserting primary buffer pointer at beginning
 
       // Optional monitor for zip time profiling.
       Double_t start = 0;
@@ -645,6 +646,10 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file, Int_t bas
 
       Int_t configArraySize = fBranch->GetConfigArraySize();
       char *configArray = fBranch->GetConfigArray();
+      if (doPrecisionCascades) {
+         precisionCascades.insert(precisionCascades.begin(),rawCompressedObjectBuffer);
+         nins.assign(precisionCascades.size(),0);
+      }
 
       // Unzip all the compressed objects in the compressed object buffer.
       while (1) {
@@ -1304,6 +1309,13 @@ Int_t TBasket::WriteBuffer()
             nouts.assign(precisionCascades.size(),0);
          }
       }
+      auto doPrecisionCascades = (!precisionCascades.empty()); // decide before inserting primary buffer pointer at beginning
+      if (doPrecisionCascades) {
+         precisionCascades.insert(precisionCascades.begin(),bufcur);
+         cxlevels.insert(cxlevels.begin(),cxlevel);
+         nouts.assign(precisionCascades.size(),0);
+      }
+
 
 
       for (Int_t i = 0; i < nbuffers; ++i) {

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1301,7 +1301,6 @@ Int_t TBasket::WriteBuffer()
             R__SizeBuffer(*cascade_buffer, buflen);
             cascade_buffer->SetWriteMode();
             precisionCascades.push_back( cascade_buffer->Buffer() + cascade_basket->GetKeylen() );
-            cxlevels.push_back(cxlevel); // WRONG! From where do we get the cxlevels of the precision cascade?
             nouts.assign(precisionCascades.size(),0);
          }
       }


### PR DESCRIPTION
Missing: array of compression levels (contents for cxlevels vector)
Not sure I have everything else correct in TBasket, but it does compile for me.
Makes PR #12 obsolete.