### PR TITLE
ZIG tests : First attempt at registering PrecisionCascade for writing TBranch+TTree

### DIFF
--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -184,7 +184,7 @@ public:
 
 };
 
-class PrecisionCascadeCompressionConfig : CompressionConfig
+class PrecisionCascadeCompressionConfig : public CompressionConfig
 {
 public:
 PrecisionCascadeCompressionConfig(RCompressionSetting::EAlgorithm::EValues algo,

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -271,6 +271,7 @@ public:
            void      PrintCacheInfo() const;
    virtual void      ReadBasket(TBuffer &b);
            void      Register(UInt_t level, ROOT::Detail::TBranchPrecisionCascade &);
+           void      Register(UInt_t level);
    virtual void      Refresh(TBranch *b);
    virtual void      Reset(Option_t *option="");
    virtual void      ResetAfterMerge(TFileMergeInfo *);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -584,6 +584,7 @@ public:
    virtual void            RemoveExternalFriend(TFriendElement *);
    virtual void            RemoveFriend(TTree*);
    virtual void            RecursiveRemove(TObject *obj);
+   void Register(UInt_t level);
    virtual void            Reset(Option_t* option = "");
    virtual void            ResetAfterMerge(TFileMergeInfo *);
    virtual void            ResetBranchAddress(TBranch *);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -3287,6 +3287,22 @@ void TTree::Register(UInt_t level, ROOT::Detail::TTreePrecisionCascade &precisio
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Register a new TTreePrecisionCascade.
+void TTree::Register(UInt_t level)
+{
+   if (!fPrecisionCascades)
+      fPrecisionCascades = new std::vector<ROOT::Detail::TTreePrecisionCascade *>;
+   // CHECK: should we require registration in incremental order?
+   if (fPrecisionCascades->size() < level +1)
+   {
+      fPrecisionCascades->resize(level + 1);
+      (*fPrecisionCascades)[level] = new ROOT::Detail::TTreePrecisionCascade(*this,level);
+   }
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Open and connect to the Precission Cascade files when present.
 /// Returns the number of opened files.
 


### PR DESCRIPTION
This first attempt at registering PrecisionCascade for writing TBranch and TTree...
1) Would not compile unless I gave the full (not relative) path for core/zip/src/PrecisionCascadeConfigArrayContent.h as it is not in an include path.
2) Crashed upon running, and I have not yet debugged why.

-Gene