### PR TITLE
A few changes to properly pass storeResidual to BLAST

### DIFF
--- a/core/accelogic/inc/ZipAccelogic.h
+++ b/core/accelogic/inc/ZipAccelogic.h
@@ -14,7 +14,7 @@
 
 #include "EDataType.h"
 
-void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, EDataType datatype = EDataType::kNoType_t);
+void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tgts, int tgt_number, int *irep, bool storeResidual, EDataType datatype = EDataType::kNoType_t);
 
 void R__unzipBLAST(int *srcsize, unsigned char **srcs, int *tgtsize, unsigned char *tgt, int src_number, int *irep);
 
@@ -24,7 +24,7 @@ void R__unzipBLAST(int *srcsize, unsigned char **srcs, int *tgtsize, unsigned ch
 extern "C" {
 #endif
 
-void R__zipBLAST(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, EDataType datatype = EDataType::kNoType_t);
+void R__zipBLAST(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, bool storeResidual, EDataType datatype = EDataType::kNoType_t);
 
 void R__unzipBLAST(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
 

--- a/core/accelogic/src/ZipAccelogic.cxx
+++ b/core/accelogic/src/ZipAccelogic.cxx
@@ -188,9 +188,10 @@ void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tg
       // tgt[2] is set for each target buffer above
 
       // Include the 2 extra header byte into the out size.
-      tgt[3] = (char)((out_sizes[tgt_idx] + 2) & 0xff);
-      tgt[4] = (char)((out_sizes[tgt_idx] >> 8) & 0xff);
-      tgt[5] = (char)((out_sizes[tgt_idx] >> 16) & 0xff);
+      size_t out_size = out_sizes[tgt_idx] + 2;
+      tgt[3] = (char)(out_size & 0xff);
+      tgt[4] = (char)((out_size >> 8) & 0xff);
+      tgt[5] = (char)((out_size >> 16) & 0xff);
 
       tgt[6] = (char)(in_size & 0xff);         /* decompressed size */
       tgt[7] = (char)((in_size >> 8) & 0xff);

--- a/core/accelogic/src/ZipAccelogic.cxx
+++ b/core/accelogic/src/ZipAccelogic.cxx
@@ -87,13 +87,13 @@ void R__zipBLAST(int *cxlevels, int *srcsize, char *src, int *tgtsize, char **tg
       size_t float_number = *srcsize / elsize;
       // Use "absSens".
       int absSensLevels[MAX_ZIG_BUFFERS];
-      // We shift the request config from [1,71] to [-60, 10]
-      for (int tgt_idx=0; tgt_idx<tgt_number; tgt_idx++)
-         absSensLevels[tgt_idx] = cxlevels[tgt_idx] - 61;
       // blast1_compress needs to know whether to keep the residual, and does not count
       // the residual among the target buffers. Final buffer's cxlevel
       // is irrelevant if it will be the residual buffer.
       auto absSens_tgt_number = tgt_number - (storeResidual ? 1 : 0);
+      // We shift the request config from [1,71] to [-60, 10]
+      for (int tgt_idx=0; tgt_idx<absSens_tgt_number; tgt_idx++)
+         absSensLevels[tgt_idx] = cxlevels[tgt_idx] - 61;
       // Note: We need to check the source really start of a float boundary.
       // Note: We need to upgrade blast to avoid the memcpy (which is IN ADDITION to an internal copy already!!!)
       char *staging[MAX_ZIG_BUFFERS] = { nullptr };

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -131,7 +131,6 @@ void R__zipPrecisionCascade(int *srcsize, char *src, int *tgtsize, char **tgts, 
       return;
    }
    auto content = reinterpret_cast<ROOT::Internal::PrecisionCascadeConfigArrayContent*>(configarray);
-   (void) configsize;
    assert(content && (content->SizeOf() == (size_t)configsize));
    Int_t *cxlevels = content->GetLevels();  // This an array of size `content->fLen`
 


### PR DESCRIPTION
While this fixes several little issues, it has not resolved problems I see with reading a precision cascade where the residual is stored. Still looking into that, but figured I'd go ahead and get these patches in.