### PR TITLE
Initial version of TBranchPrecisionCascade Print

### DIFF
--- a/tree/tree/inc/TBranchPrecisionCascade.h
+++ b/tree/tree/inc/TBranchPrecisionCascade.h
@@ -54,6 +54,8 @@ public:
 
    char *RetrieveCascade(TTree &tree, Int_t basketnumber);
 
+   void Print(Option_t *option="") const;
+
    ClassDef(TBranchPrecisionCascade, 3);
 };
 

--- a/tree/tree/src/TBranchPrecisionCascade.cxx
+++ b/tree/tree/src/TBranchPrecisionCascade.cxx
@@ -23,6 +23,7 @@ supplemental parts of the precision cascades for a specific branch.
 #include "TStorage.h"
 #include "TTree.h"
 #include "TFile.h"
+#include <iostream>
 
 namespace ROOT {
 namespace Detail {
@@ -114,6 +115,15 @@ char *TBranchPrecisionCascade::RetrieveCascade(TTree &tree, Int_t basketnumber)
 
    // Do we need to also return fBasketBytes[fBasketSeek] ?
    return basket->GetBuffer();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Print the object's information.
+void TBranchPrecisionCascade::Print(Option_t * /* option = "" */) const
+{
+   std::cout << "TBranchPrecisionCascade: " << GetName()
+             << "\tlevel: " << fCascadeLevel
+             << "\tBasket Size: " << (fBasketBytes ? *fBasketBytes : 0) << std::endl;
 }
 
 } // Details

--- a/tree/tree/src/TBranchPrecisionCascade.cxx
+++ b/tree/tree/src/TBranchPrecisionCascade.cxx
@@ -123,7 +123,7 @@ void TBranchPrecisionCascade::Print(Option_t * /* option = "" */) const
 {
    std::cout << "TBranchPrecisionCascade: " << GetName()
              << "\tlevel: " << fCascadeLevel
-             << "\tBasket Size: " << (fBasketBytes ? *fBasketBytes : 0) << std::endl;
+             << "\tBasket Size (approx): " << (fBasketBytes ? *fBasketBytes : 0) << std::endl;
 }
 
 } // Details

--- a/tree/tree/src/TTreePrecisionCascade.cxx
+++ b/tree/tree/src/TTreePrecisionCascade.cxx
@@ -69,6 +69,8 @@ void TTreePrecisionCascade::Print(Option_t * /* option = "" */) const
              << "\tTTree uniqueID: " << fTreeRef.GetUniqueID()
              << "\tTTree pid: " << fTreeRef.GetPID()->GetUniqueID()
              << "\tlevel: " << fCascadeLevel << std::endl;
+   for (auto b : fBranches)
+      if (b) b->Print();
 }
 
 // Create a new TBranchPrecisionCascade


### PR DESCRIPTION
This very basic version of `Print()` allows one to see which branches are in the PrecisionCascade files. I expect there is considerable room for improvement to this function, but this initial version is already helpful. The printing includes the detail of whether each branch's PrecisionCascade levels extend to the level of the PrecisionCascade file under examination. In other words, if one branch is saved with 3 levels (which may be 2 + 1 residual, or 3 + 0 residual) and another branch is saved with 2 levels (either 1 + 1 residual, or 2 + 0 residual), then the branches with only 2 levels will not show up in the third file, which is good to know.

In the example below, the branches' compression configuration levels (from a TTree name "PicoDst") were set as:

    Track.mGMomentumX -> 2 + 0 residual
    Track.mGMomentumY -> 1 + 1 residual
    Track.mGMomentumZ -> 2 + 1 residual

And here's what the Print() as implemented in this PR helpfully shows:

> root -l -b -q gp_all.root.55_precisioncascade_1.root -e 'PicoDst_pc1->Print()'

Attaching file gp_all.root.55_precisioncascade_1.root as _file0...
(TFile *) 0x7fafa20d7560
TTreePrecisionCascade: PicoDst_pc1	TTree uniqueID: 1	TTree pid: 1	level: 1
TBranchPrecisionCascade: Track.mGMomentumX	level: 1	Basket Size: 163858
TBranchPrecisionCascade: Track.mGMomentumY	level: 1	Basket Size: 685917
TBranchPrecisionCascade: Track.mGMomentumZ	level: 1	Basket Size: 172095

> root -l -b -q gp_all.root.55_precisioncascade_2.root -e 'PicoDst_pc2->Print()'

Attaching file gp_all.root.55_precisioncascade_2.root as _file0...
(TFile *) 0x7fe4a48f1d90
TTreePrecisionCascade: PicoDst_pc2	TTree uniqueID: 1	TTree pid: 1	level: 2
TBranchPrecisionCascade: Track.mGMomentumZ	level: 2	Basket Size: 567419


