### PR TITLE
Handle headers for integer types with precision cascades

### DIFF
--- a/core/accelogic/src/ZipAccelogic.cxx
+++ b/core/accelogic/src/ZipAccelogic.cxx
@@ -77,7 +77,7 @@ void R__zipBLAST(unsigned char *cxlevels, int *srcsize, char *src, int *tgtsize,
    bool isfloat = (rawtype == EDataType::kFloat_t);
    bool isdouble = (rawtype == EDataType::kDouble_t);
 
-   size_t out_sizes[MAX_ZIG_BUFFERS] = { 0 };
+   size_t out_sizes[MAX_ZIG_BUFFERS] = { };
 
    if (isfloat || isdouble) {
       const size_t elsize = isfloat ? sizeof(float) : sizeof(double);
@@ -110,16 +110,11 @@ void R__zipBLAST(unsigned char *cxlevels, int *srcsize, char *src, int *tgtsize,
       for (int tgt_idx=0; tgt_idx<tgt_number && !excessive_size; tgt_idx++)
          excessive_size |= ( ( out_sizes[tgt_idx] + kHeaderSize) > (size_t)tgtsize[tgt_idx] );
 
-      if (excessive_size) {
-         for (int tgt_idx=0; tgt_idx<tgt_number; tgt_idx++)
-           delete [] (staging[tgt_idx]);
-         return;
-      }
-
       for (int tgt_idx=0; tgt_idx<tgt_number; tgt_idx++) {
-         memcpy(tgts[tgt_idx] + kHeaderSize, staging[tgt_idx], out_sizes[tgt_idx]);
-         delete [] (staging[tgt_idx]);         irep[tgt_idx] = out_sizes[tgt_idx] + kHeaderSize;
+         if (!excessive_size) memcpy(tgts[tgt_idx] + kHeaderSize, staging[tgt_idx], out_sizes[tgt_idx]);
+         delete [] (staging[tgt_idx]);
       }
+      if (excessive_size) return;
    } else {
       // Use "RLE".
       // Note: We need to check the source really start of a boundary.

--- a/core/accelogic/src/ZipAccelogic.cxx
+++ b/core/accelogic/src/ZipAccelogic.cxx
@@ -106,6 +106,7 @@ void R__zipBLAST(unsigned char *cxlevels, int *srcsize, char *src, int *tgtsize,
       else
          blast1_compress<true>(absSensLevels, source.d, float_number, staging, out_sizes, absSens_tgt_number, needresidual);
 
+      // Skip transfer any of the buffers to their targets if any one of them is over-sized, and return
       auto excessive_size = false;
       for (int tgt_idx=0; tgt_idx<tgt_number && !excessive_size; tgt_idx++)
          excessive_size |= ( ( out_sizes[tgt_idx] + kHeaderSize) > (size_t)tgtsize[tgt_idx] );
@@ -192,7 +193,7 @@ void R__zipBLAST(unsigned char *cxlevels, int *srcsize, char *src, int *tgtsize,
       tgt[10] = tgt_number;
 
       // irep points to an array of all buffer sizes
-      irep[tgt_idx] = out_sizes[tgt_idx] + kHeaderSize; // out_sizes will be 0 for RLE secondary targets
+      irep[tgt_idx] = out_sizes[tgt_idx] + kHeaderSize; // out_sizes will be 0 for RLE auxiliary targets
    }
 }
 


### PR DESCRIPTION
Blast does not provide the precision cascade functionality to integer-types, and they are appropriately differentiated from real-type data in core/accelogic/src/ZipAccelogic.cxx. In principle, the cascade settings should be irrelevant for such types, but the tasks for setting up a precision cascade are done without any check on the data type, so the TBranchPrecisionCascade objects and cascade files are all done before ZipAccelogic's functionality is called. It is simpler to make sure those objects are properly handled for this case than it is to put in the logic to avoid setting up the TBranchPrecisionCascade objects for integer types, even though the latter might seem "cleaner" from a user perspective.

To that end, even if a TBranchPrecisionCascade is generated for such types, the information in the auxiliary cascade tiers should be unimportant. But headers are necessary for these objects to make sense, and presently there is an attempt to read the headers but they don't make sense. This commit achieves the desired result, with appropriate headers indicating that there is no actual content in the auxiliary tiers.

I have done some testing, including reading back with and without the auxiliary files demonstrating that they are in fact inconsequential for the readback.